### PR TITLE
Dont position the main-icons absolute

### DIFF
--- a/src/FAB.vue
+++ b/src/FAB.vue
@@ -284,12 +284,10 @@
 
     .fab .material-icons.main {
         opacity: 1;
-        position: absolute;
     }
 
     .fab .material-icons.close {
         opacity: 0;
-        position: absolute;
     }
 
     .fab .material-icons.main.rotate {


### PR DESCRIPTION
Positioning the main-icons absolute results in weird positioning in IE,
Firefox and Safari.

Removing this fixed the issue for me in Firefox and Safari. I did not test the behaviour in IE.