### PR TITLE
#14 Remove check for $refs

### DIFF
--- a/src/FAB.vue
+++ b/src/FAB.vue
@@ -261,7 +261,7 @@
                 }
             },
             showTooltip(show) {
-                if (show && this.$refs.actions && this.fixedTooltip) {
+                if (show && this.actions.length && this.fixedTooltip) {
 
                     //timeout to prevent wrong position for the tooltip
                     setTimeout(() => {


### PR DESCRIPTION
Instead of $refs a check is made for actions.length. Because $refs is initialised only after the function.